### PR TITLE
accept button disappear if capacity reached

### DIFF
--- a/app/policies/participation_policy.rb
+++ b/app/policies/participation_policy.rb
@@ -29,6 +29,14 @@ class ParticipationPolicy < ApplicationPolicy
     end
   end
 
+  def accept?
+    if user.nil?
+      false
+    else
+      record.jamm.creator_id == user.id && record.user != user && record.jamm.capacity != record.jamm.participations.where(status: 'Accepted').size
+    end
+  end
+
   private
 
   def is_user?

--- a/app/views/jamms/_participation.html.erb
+++ b/app/views/jamms/_participation.html.erb
@@ -9,6 +9,6 @@
     <%= link_to "Cancel my participation", jamm_participation_path(participation), method: :delete,
     data: { confirm: "Are you sure ?"} %>
   <% end %>
-  <% if policy(participation).status? %>
-   <p><%= link_to "Accept", jamm_accept_path(participation), method: :patch %> <%= link_to "Refuse", jamm_refuse_path(participation), method: :patch %></p><% end %>
+  <% if policy(participation).accept? %>
+   <%= link_to "Accept", jamm_accept_path(participation), method: :patch %><% end %> <% if policy(participation).status? %><%= link_to "Refuse", jamm_refuse_path(participation), method: :patch %><% end %>
 </div><br>


### PR DESCRIPTION
The accept link for a participant disappear for the creator if he reaches the capacity of his jam session