### PR TITLE
fix the link of jam toolbar

### DIFF
--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -77,7 +77,7 @@
       <i class="fas fa-home"></i></a>
     <a class="jam-options-link" href="/dashboard" target="_self">
       <i class="fas fa-user"></i></a>
-    <a class="jam-options-link" href="" target="_self">
+    <a class="jam-options-link" href="/jamms" target="_self">
       <i class="fas fa-search"></i>
     </a>
     <%= link_to destroy_user_session_path, method: :delete, class: "jam-options-link",target:"_self",rel:"nofollow" do %>


### PR DESCRIPTION
The loop on the jam toolbar redirect to jamms index page